### PR TITLE
Memory allocation updates

### DIFF
--- a/chapter4/chapter4.md
+++ b/chapter4/chapter4.md
@@ -234,29 +234,29 @@ A Vertex Array Objects (VAOs). A VAO is an object that contains one or more VBOs
  
 A VAO is like a wrapper that groups a set of definitions for the data is going to be stored in the graphics card. When we create a VAO we  get an identifier, we use that identifier to render it and the elements it contains using the definitions we specified during its creation.
 
-So let us continue coding our example. The first thing that we must do with is to store our array of floats into a ```FloatBuffer```. This is mainly due to the fact that we must interface with OpenGL library, which is C-bases, so we must transform our array of floats into something that can be managed by the library.
+So let us continue coding our example. The first thing that we must do is to store our array of floats into a ```FloatBuffer```. This is mainly due to the fact that we must interface with the OpenGL library, which is C-based, so we must transform our array of floats into something that can be managed by the library. 
 
 ```java
-FloatBuffer verticesBuffer =
-	BufferUtils.createFloatBuffer(vertices.length);
+FloatBuffer verticesBuffer = memAllocFloat(vertices.length);
 verticesBuffer.put(vertices).flip();
 ```
 
-We use a utility class to create the buffer and after we have stored the data (with the put method) we need to reset the position of the buffer to the 0 position with the flip method (that is, we say that we’ve finishing writing on it).
+We use a utility class to create the buffer in off-heap memory so that it's accessible by the OpenGL library. After we have stored the data (with the put method) we need to reset the position of the buffer to the 0 position with the flip method (that is, we say that we’ve finishing writing on it).
 
-Now  we need to create the VAO and bind to it.
+Now we need to create the VAO and bind to it.
 
 ```java
 vaoId = glGenVertexArrays();
 glBindVertexArray(vaoId);
 ```
 
-Then, we need to create or VBO, bind to it and put the data into it.
+Then we need to create the VBO, bind to it and put the data into it. Once this has been completed we **must** free the off-heap memory that was allocated to the FloatBuffer. This is done by manually calling memFree, as Java garbage collection will not clean up off-heap allocations.
 
 ```java
 vboId = glGenBuffers();
 glBindBuffer(GL_ARRAY_BUFFER, vboId);
 glBufferData(GL_ARRAY_BUFFER, verticesBuffer, GL_STATIC_DRAW);
+memFree(verticiesBuffer);
 ```
 
 Now it comes the most important part, we need to define the structure of our data and store in one of the attribute lists of the VAO, this is done with the following line.

--- a/chapter5/chapter5.md
+++ b/chapter5/chapter5.md
@@ -157,7 +157,7 @@ IntBuffer indicesBuffer = memAllocInt(indices.length);
 indicesBuffer.put(indices).flip();
 glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, idxVboId);
 glBufferData(GL_ELEMENT_ARRAY_BUFFER, indicesBuffer, GL_STATIC_DRAW);
-memFree(indiciesBuffer);
+memFree(indicesBuffer);
 ```
 
 Since we are dealing with integers we need to create an ```IntBuffer``` instead of a ```FloatBuffer```.

--- a/chapter5/chapter5.md
+++ b/chapter5/chapter5.md
@@ -7,7 +7,7 @@ In this Chapter we will continue talking about how OpenGL renders things. In ord
 package org.lwjglb.engine.graph;
 
 import java.nio.FloatBuffer;
-import org.lwjgl.BufferUtils;
+import static org.lwjgl.system.MemoryUtil.*;
 import static org.lwjgl.opengl.GL11.*;
 import static org.lwjgl.opengl.GL15.*;
 import static org.lwjgl.opengl.GL20.*;
@@ -23,7 +23,7 @@ public class Mesh {
     
     public Mesh(float[] positions) {
         vertexCount = positions.length / 3;
-        FloatBuffer verticesBuffer = BufferUtils.createFloatBuffer(positions.length);
+        FloatBuffer verticesBuffer = memAllocFloat(positions.length);
         verticesBuffer.put(positions).flip();
 
         vaoId = glGenVertexArrays();
@@ -32,6 +32,7 @@ public class Mesh {
         vboId = glGenBuffers();
         glBindBuffer(GL_ARRAY_BUFFER, vboId);
         glBufferData(GL_ARRAY_BUFFER, verticesBuffer, GL_STATIC_DRAW);
+        memFree(verticiesBuffer);
         glVertexAttribPointer(0, 3, GL_FLOAT, false, 0, 0);
         glBindBuffer(GL_ARRAY_BUFFER, 0);
 
@@ -152,10 +153,11 @@ After we have created our VBO that stores the positions, we need to create anoth
 
 ```java
 idxVboId = glGenBuffers();
-IntBuffer indicesBuffer = BufferUtils.createIntBuffer(indices.length);
+IntBuffer indicesBuffer = memAllocInt(indices.length);
 indicesBuffer.put(indices).flip();
 glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, idxVboId);
 glBufferData(GL_ELEMENT_ARRAY_BUFFER, indicesBuffer, GL_STATIC_DRAW);
+memFree(indiciesBuffer);
 ```
 
 Since we are dealing with integers we need to create an ```IntBuffer``` instead of a ```FloatBuffer```.
@@ -224,10 +226,11 @@ With that array, we will create another VBO which will be associated to our VAO.
 ```java
 // Colour VBO
 colourVboId = glGenBuffers();
-FloatBuffer colourBuffer = BufferUtils.createFloatBuffer(colours.length);
+FloatBuffer colourBuffer = memAllocFloat(colours.length);
 colourBuffer.put(colours).flip();
 glBindBuffer(GL_ARRAY_BUFFER, colourVboId);
 glBufferData(GL_ARRAY_BUFFER, colourBuffer, GL_STATIC_DRAW);
+memFree(colourBuffer);
 glVertexAttribPointer(1, 3, GL_FLOAT, false, 0, 0);
 ```
 


### PR DESCRIPTION
Updates to the book text for chapter 4 and 5 (Rendering and More on Rendering) to remove the BufferUtils method for off-heap memory allocation and instead use the memAlloc methods provided in org.lwjgl.system.MemoryUtil.

The memFree method calls have been placed immediately after the buffers are accessed by the OpenGL library. These calls could be moved if it's felt that improves readability of the code.

