### PR TITLE
removed misplaced `memFree`

### DIFF
--- a/chapter04/chapter4.md
+++ b/chapter04/chapter4.md
@@ -262,7 +262,6 @@ Then we need to create the VBO, bind it and put the data into it.
 vboId = glGenBuffers();
 glBindBuffer(GL_ARRAY_BUFFER, vboId);
 glBufferData(GL_ARRAY_BUFFER, verticesBuffer, GL_STATIC_DRAW);
-memFree(verticesBuffer);
 ```
 
 Now comes the most important part. We need to define the structure of our data and store it in one of the attribute lists of the VAO. This is done with the following line.


### PR DESCRIPTION
Hi!  I'm actually not sure if this is a mistake or not, but it seemed extraneous because of the call to `MemoryUtil.memFree` after unbinding the VBO and VAO.

Before removing `memFree(verticesBuffer)`, I received this error:
`java(7450,0x7fffa17c53c0) malloc: *** error for object 0x7f89359e7350: pointer being freed was not allocated`

Thanks for your time!