### PR TITLE
Missing light.intensity in specular light calculation in sample.

### DIFF
--- a/chapter10/chapter10.md
+++ b/chapter10/chapter10.md
@@ -274,7 +274,7 @@ vec4 calcPointLight(PointLight light, vec3 position, vec3 normal)
     vec3 reflected_light = normalize(reflect(from_light_source, normal));
     float specularFactor = max( dot(camera_direction, reflected_light), 0.0);
     specularFactor = pow(specularFactor, specularPower);
-    specColour = speculrC * specularFactor * material.reflectance * vec4(light.colour, 1.0);
+    specColour = speculrC * specularFactor * material.reflectance * light.intensity * vec4(light.colour, 1.0);
 
     // Attenuation
     float distance = length(light_direction);


### PR DESCRIPTION
Based on the the book here - https://ahbejarano.gitbook.io/lwjglgamedev/chapter10#specular-component
`specularColour ∗ lColour ∗ reflectance ∗ specularFactor ∗ intensity`

Updated the sample provided to calculate specular colour as it was missing light intensity.