### PR TITLE
Update typo in Chapter 17 - Normal Mapping

### DIFF
--- a/chapter17/chapter17.md
+++ b/chapter17/chapter17.md
@@ -100,7 +100,7 @@ in mat4 outModelViewMatrix;
 In the fragment shader, we will need to pass a new uniform for the normal map texture sampler:
 
 ```glsl
-uniform sampler2D texture_sampler;
+uniform sampler2D normalMap;
 ```
 
 Also, in the fragment shader, we will create a new function that calculates the normal for the current fragment.


### PR DESCRIPTION
The book text implies the following fragment should contain a description for a new shader uniform, however, it specifies the existing shader uniform for `uniform sampler2D texture_sampler;` where I believe `uniform sampler2D normalMap;` was intended.  The supplementary code provided in the GitHub project is correct.