### PR TITLE
Fix subtle bug in mesh cleanUp function

### DIFF
--- a/chapter04/chapter4.md
+++ b/chapter04/chapter4.md
@@ -339,7 +339,8 @@ public void cleanup() {
     if (shaderProgram != null) {
         shaderProgram.cleanup();
     }
-
+    
+    glBindVertexArray(vaoId);
     glDisableVertexAttribArray(0);
 
     // Delete the VBO

--- a/chapter05/chapter5.md
+++ b/chapter05/chapter5.md
@@ -51,6 +51,7 @@ public class Mesh {
     }
 
     public void cleanUp() {
+        glBindVertexArray(vaoId);
         glDisableVertexAttribArray(0);
 
         // Delete the VBO


### PR DESCRIPTION
The vertex array needs to be bound before disabling its attrib array and such. In this super simple project there's only one possible thing that could be bound. But since code here likely gets copied and pasted a lot, I think this correctness will help avoid some nasty bugs.